### PR TITLE
refactor(core): extract scanner logic and fix concurrency issues

### DIFF
--- a/src/maia/application/scan_result_model.cpp
+++ b/src/maia/application/scan_result_model.cpp
@@ -2,207 +2,52 @@
 
 #include "maia/application/scan_result_model.h"
 
-#include <algorithm>
-#include <array>
+#include <chrono>
 #include <future>
-#include <span>
 #include <thread>
-#include <vector>
 
-#include "maia/assert.h"
-#include "maia/core/scoped_process_suspend.h"
-#include "maia/core/simd_scanner.h"
 #include "maia/logging.h"
-#include "maia/mmem/mmem.h"
 
 namespace maia {
 
 namespace {
 
-// Represents a single chunk of memory to scan.
-struct ScanTask {
-  uintptr_t base_address;  // Virtual address in the target process
-  size_t scan_size;        // Logical chunk size (what we report matches within)
-  size_t read_size;  // Actual bytes to read (includes overlap for patterns)
-};
-
-// We check flags to stop crashes when reading protected memory like guard
-// pages.
-constexpr bool IsReadable(mmem::Protection prot) noexcept {
-  const auto prot_val = static_cast<uint32_t>(prot);
-  const auto read_val = static_cast<uint32_t>(mmem::Protection::kRead);
-  return (prot_val & read_val) != 0;
-}
-
 bool CanScan(IProcess* process) {
   return process && process->IsProcessValid();
 }
 
-// Copying to a local array fixes crashes on systems that hate unaligned memory
-// reads before casting.
-template <typename T>
-  requires std::is_trivially_copyable_v<T>
-constexpr T LoadValue(std::span<const std::byte> bytes) {
-  std::array<std::byte, sizeof(T)> buffer{};
-  const size_t copy_size = std::min(bytes.size(), sizeof(T));
-  std::copy_n(bytes.begin(), copy_size, buffer.begin());
-  return std::bit_cast<T>(buffer);
-}
-
-// Byte comparison is faster than decoding types and catches all changes
-// including padding or NaN data.
-constexpr bool IsValueChanged(std::span<const std::byte> current,
-                              std::span<const std::byte> previous) {
-  if (current.size() != previous.size()) {
-    return false;
-  }
-  return !std::ranges::equal(current, previous);
-}
-
-template <typename T>
-  requires std::is_trivially_copyable_v<T>
-constexpr bool IsValueDecreased(std::span<const std::byte> current,
-                                std::span<const std::byte> previous) {
-  if (current.size() < sizeof(T) || previous.size() < sizeof(T)) {
-    return false;
-  }
-  return LoadValue<T>(current) < LoadValue<T>(previous);
-}
-
-template <typename T>
-  requires std::is_trivially_copyable_v<T>
-constexpr bool IsValueIncreased(std::span<const std::byte> current,
-                                std::span<const std::byte> previous) {
-  if (current.size() < sizeof(T) || previous.size() < sizeof(T)) {
-    return false;
-  }
-  return LoadValue<T>(current) > LoadValue<T>(previous);
-}
-
-template <typename T>
-  requires std::is_trivially_copyable_v<T>
-constexpr bool IsValueIncreasedBy(std::span<const std::byte> current,
-                                  std::span<const std::byte> previous,
-                                  std::span<const std::byte> target) {
-  if (current.size() < sizeof(T) || previous.size() < sizeof(T) ||
-      target.size() < sizeof(T)) {
-    return false;
-  }
-  return LoadValue<T>(current) == LoadValue<T>(previous) + LoadValue<T>(target);
-}
-
-template <typename T>
-  requires std::is_trivially_copyable_v<T>
-constexpr bool IsValueDecreasedBy(std::span<const std::byte> current,
-                                  std::span<const std::byte> previous,
-                                  std::span<const std::byte> target) {
-  if (current.size() < sizeof(T) || previous.size() < sizeof(T) ||
-      target.size() < sizeof(T)) {
-    return false;
-  }
-  return LoadValue<T>(current) == LoadValue<T>(previous) - LoadValue<T>(target);
-}
-
-template <typename F, typename T>
-concept CheckScanType = requires(F& f) {
-  { f.template operator()<T>() } -> std::convertible_to<bool>;
-};
-
-template <typename F>
-concept CScanPredicate = CheckScanType<F, uint8_t> &&
-                         CheckScanType<F, uint64_t> && CheckScanType<F, double>;
-
-// This helper stops us from writing the same switch statement inside every loop
-// by connecting runtime enums to compile-time templates.
-// clang-format off
-template <CScanPredicate Func>
-constexpr auto DispatchScanType(ScanValueType type, Func&& func) {
-  switch (type) {
-    case ScanValueType::kUInt8:  return func.template operator()<uint8_t>();
-    case ScanValueType::kUInt16: return func.template operator()<uint16_t>();
-    case ScanValueType::kUInt32: return func.template operator()<uint32_t>();
-    case ScanValueType::kUInt64: return func.template operator()<uint64_t>();
-    case ScanValueType::kInt8:   return func.template operator()<int8_t>();
-    case ScanValueType::kInt16:  return func.template operator()<int16_t>();
-    case ScanValueType::kInt32:  return func.template operator()<int32_t>();
-    case ScanValueType::kInt64:  return func.template operator()<int64_t>();
-    case ScanValueType::kFloat:  return func.template operator()<float>();
-    case ScanValueType::kDouble: return func.template operator()<double>();
-    case ScanValueType::kString:
-    case ScanValueType::kWString:
-    case ScanValueType::kArrayOfBytes:
-      return false; // Not supported for arithmetic comparisons
-    default: return false;
-  }
-}
-
-constexpr size_t GetDataTypeSize(ScanValueType type) {
-  switch (type) {
-    case ScanValueType::kUInt8:  return sizeof(uint8_t);
-    case ScanValueType::kUInt16: return sizeof(uint16_t);
-    case ScanValueType::kUInt32: return sizeof(uint32_t);
-    case ScanValueType::kUInt64: return sizeof(uint64_t);
-    case ScanValueType::kInt8:   return sizeof(int8_t);
-    case ScanValueType::kInt16:  return sizeof(int16_t);
-    case ScanValueType::kInt32:  return sizeof(int32_t);
-    case ScanValueType::kInt64:  return sizeof(int64_t);
-    case ScanValueType::kFloat:  return sizeof(float);
-    case ScanValueType::kDouble: return sizeof(double);
-    case ScanValueType::kString:
-    case ScanValueType::kWString:
-    case ScanValueType::kArrayOfBytes:
-      return 1; // Byte alignment by default for variable types
-    default: return sizeof(uint32_t);
-  }
-}
-
-// clang-format on
-
-void ClearStorage(ScanStorage& storage) {
-  storage.addresses.clear();
-  storage.curr_raw.clear();
-  storage.prev_raw.clear();
-  storage.stride = 0;
-}
-
-template <typename CheckFunc>
-void PerformNextScanScalar(const std::vector<std::byte>& current_memory_buffer,
-                           const ScanStorage& scan_storage,
-                           size_t count,
-                           size_t stride,
-                           ScanStorage& filtered_storage,
-                           CheckFunc&& check_condition) {
-  const std::byte* curr_ptr = current_memory_buffer.data();
-  const std::byte* prev_ptr = scan_storage.prev_raw.data();
-
-  for (size_t i = 0; i < count; ++i) {
-    std::span<const std::byte> val_curr(curr_ptr, stride);
-    std::span<const std::byte> val_prev(prev_ptr, stride);
-
-    if (check_condition(val_curr, val_prev, i)) {
-      filtered_storage.addresses.emplace_back(scan_storage.addresses[i]);
-
-      filtered_storage.curr_raw.insert(
-          filtered_storage.curr_raw.end(), val_curr.begin(), val_curr.end());
-
-      filtered_storage.prev_raw.insert(
-          filtered_storage.prev_raw.end(), val_curr.begin(), val_curr.end());
-    }
-
-    curr_ptr += stride;
-    prev_ptr += stride;
-  }
-}
-
 }  // namespace
 
-ScanResultModel::ScanResultModel(std::unique_ptr<core::ITaskRunner> task_runner,
-                                 size_t chunk_size)
-    : task_runner_(std::move(task_runner)),
-      chunk_size_(chunk_size) {
-  if (!task_runner_) {
-    task_runner_ = std::make_unique<core::AsyncTaskRunner>();
+ScanResultModel::ScanResultModel(size_t chunk_size)
+    : session_(std::make_shared<core::ScanSession>()) {
+  scanner_.SetChunkSize(chunk_size);
+}
+
+ScanResultModel::~ScanResultModel() {
+  CancelScan();
+  StopAutoUpdate();
+}
+
+core::ScanConfig ScanResultModel::BuildScanConfig(bool use_previous) const {
+  core::ScanConfig config;
+  config.value_type = scan_value_type_;
+  config.comparison = scan_comparison_;
+  config.value = target_scan_value_;
+  config.mask = target_scan_mask_;
+
+  size_t type_size = GetSizeForType(scan_value_type_);
+  if (type_size == 0) {
+    type_size = 1;
   }
+  config.alignment = fast_scan_enabled_ ? type_size : 1;
+
+  config.use_previous_results = use_previous;
+  config.pause_while_scanning = pause_while_scanning_enabled_;
+  return config;
+}
+
+const ScanStorage& ScanResultModel::entries() const {
+  return session_->GetStorageUnsafe();
 }
 
 void ScanResultModel::FirstScan() {
@@ -210,299 +55,34 @@ void ScanResultModel::FirstScan() {
     return;
   }
 
-  // Clear existing results immediately so UI shows empty state.
-  {
-    std::scoped_lock lock(mutex_);
-    ClearStorage(scan_storage_);
-    signals_.memory_changed.publish(scan_storage_);
-  }
-
   if (!CanScan(active_process_)) {
     LogWarning("Process is invalid for first scan.");
+    return;
+  }
+
+  session_->Clear();
+  signals_.memory_changed.publish(session_->GetStorageUnsafe());
+
+  core::ScanConfig config = BuildScanConfig(false);
+  if (!config.Validate()) {
+    LogWarning("Invalid scan configuration.");
     return;
   }
 
   LogInfo("Starting first scan...");
   is_scanning_ = true;
   progress_ = 0.0f;
-  scan_finished_flag_ = false;
+  stop_source_ = std::stop_source{};
+  pending_config_ = config;
 
-  task_runner_->Run(
-      [this](std::stop_token stop_token) { ExecuteScanWorker(stop_token); });
-}
-
-void ScanResultModel::ExecuteScanWorker(std::stop_token stop_token) {
-  // Capture necessary state by value to avoid race conditions.
-  // Note: For SyncTaskRunner, this copy is less critical but still good
-  // practice.
-  std::vector<std::byte> target_value;
-  std::vector<std::byte> target_mask;
-  ScanValueType value_type;
-  ScanComparison comparison;
-  bool pause_enabled;
-  bool fast_scan;
-  IProcess* process;
-
-  {
-    std::scoped_lock lock(mutex_);
-    target_value = target_scan_value_;
-    target_mask = target_scan_mask_;
-    value_type = scan_value_type_;
-    comparison = scan_comparison_;
-    pause_enabled = pause_while_scanning_enabled_;
-    fast_scan = fast_scan_enabled_;
-    process = active_process_;
-  }
-
-  std::optional<ScopedProcessSuspend> suspend;
-  if (pause_enabled) {
-    suspend.emplace(process);
-  }
-
-  ScanComparison effective_comparison = comparison;
-  if (effective_comparison != ScanComparison::kExactValue) {
-    effective_comparison = ScanComparison::kUnknown;
-  }
-
-  const bool is_exact_scan =
-      (effective_comparison == ScanComparison::kExactValue);
-  size_t scan_stride = 0;
-
-  if (is_exact_scan) {
-    if (target_value.empty()) {
-      is_scanning_ = false;
-      return;
-    }
-    scan_stride = target_value.size();
-  } else {
-    scan_stride = GetDataTypeSize(value_type);
-  }
-
-  if (scan_stride == 0) {
-    is_scanning_ = false;
-    return;
-  }
-
-  LogInfo("FirstScan start: stride={}, is_exact={}, mask={}",
-          scan_stride,
-          is_exact_scan,
-          !target_mask.empty());
-
-  if (is_exact_scan) {
-    std::string pattern_hex;
-    for (auto b : target_value) {
-      pattern_hex += std::format("{:02X} ", static_cast<uint8_t>(b));
-    }
-    LogInfo("Pattern: {}", pattern_hex);
-  }
-
-  // Determine alignment based on user preference.
-
-  const size_t alignment = fast_scan ? GetDataTypeSize(value_type) : 1;
-
-  ScanStorage storage;
-  storage.stride = scan_stride;
-  storage.value_type = value_type;
-
-  auto regions = process->GetMemoryRegions();
-  size_t readable_count = 0;
-  size_t total_size = 0;
-  for (const auto& r : regions) {
-    if (IsReadable(r.protection)) {
-      readable_count++;
-      total_size += r.size;
-    }
-  }
-  LogInfo("Scanning {} readable regions (total {} MB)",
-          readable_count,
-          total_size / (1024 * 1024));
-
-  const size_t overlap_size = scan_stride > 1 ? scan_stride - 1 : 0;
-  const size_t overlap = is_exact_scan ? overlap_size : 0;
-
-  std::vector<ScanTask> tasks;
-  for (const auto& region : regions) {
-    if (stop_token.stop_requested()) {
-      break;
-    }
-    if (!IsReadable(region.protection)) {
-      continue;
-    }
-
-    const uintptr_t region_end = region.base + region.size;
-    uintptr_t current_addr = region.base;
-
-    while (current_addr < region_end) {
-      size_t chunk_scan_size = std::min(chunk_size_, region_end - current_addr);
-      size_t chunk_read_size = chunk_scan_size + overlap;
-      if (current_addr + chunk_read_size > region_end) {
-        chunk_read_size = region_end - current_addr;
-      }
-
-      tasks.emplace_back(ScanTask{.base_address = current_addr,
-                                  .scan_size = chunk_scan_size,
-                                  .read_size = chunk_read_size});
-      current_addr += chunk_scan_size;
-    }
-  }
-
-  const size_t total_tasks = tasks.size();
-  if (total_tasks == 0) {
-    is_scanning_ = false;
-    return;
-  }
-
-  std::atomic<size_t> processed_tasks{0};
-
-  const size_t num_threads = std::max(1u, std::thread::hardware_concurrency());
-  std::vector<std::vector<ScanTask>> thread_batches(num_threads);
-  for (size_t i = 0; i < total_tasks; ++i) {
-    thread_batches[i % num_threads].emplace_back(tasks[i]);
-  }
-
-  auto worker = [process,
-                 is_exact_scan,
-                 scan_stride,
-                 alignment,
-                 &target_value,
-                 &target_mask,
-                 &stop_token,
-                 &processed_tasks,
-                 total_tasks,
-                 this](const std::vector<ScanTask>& batch) -> ScanStorage {
-    ScanStorage local_storage;
-    local_storage.stride = scan_stride;
-    local_storage.addresses.reserve(1024);
-    local_storage.curr_raw.reserve(1024 * scan_stride);
-
-    std::vector<std::byte> buffer;
-
-    for (const auto& task : batch) {
-      if (stop_token.stop_requested()) {
-        return {};
-      }
-
-      buffer.resize(task.read_size);
-      MemoryAddress addr = task.base_address;
-      if (!process->ReadMemory({&addr, 1}, task.read_size, buffer)) {
-        processed_tasks++;
-        progress_ = static_cast<float>(processed_tasks) /
-                    static_cast<float>(total_tasks);
-        continue;
-      }
-
-      if (is_exact_scan) {
-        auto callback = [&](size_t offset) {
-          if (offset >= task.scan_size) {
-            return;
-          }
-          LogDebug("Match found at address 0x{:X}", task.base_address + offset);
-          local_storage.addresses.emplace_back(task.base_address + offset);
-          local_storage.curr_raw.insert(local_storage.curr_raw.end(),
-                                        buffer.begin() + offset,
-                                        buffer.begin() + offset + scan_stride);
-        };
-
-        if (target_mask.empty()) {
-          core::ScanBuffer(buffer, target_value, alignment, callback);
-        } else {
-          core::ScanBufferMasked(buffer, target_value, target_mask, callback);
-        }
-      } else {
-        if (buffer.size() >= scan_stride) {
-          const size_t limit =
-              std::min(buffer.size() - scan_stride, task.scan_size);
-          for (size_t offset = 0; offset <= limit; offset += alignment) {
-            auto data_start = buffer.begin() + offset;
-            local_storage.addresses.emplace_back(task.base_address + offset);
-            local_storage.curr_raw.insert(local_storage.curr_raw.end(),
-                                          data_start,
-                                          data_start + scan_stride);
-          }
-        }
-      }
-
-      processed_tasks++;
-      progress_ =
-          static_cast<float>(processed_tasks) / static_cast<float>(total_tasks);
-    }
-    return local_storage;
-  };
-
-  std::vector<std::future<ScanStorage>> futures;
-  for (const auto& batch : thread_batches) {
-    if (!batch.empty()) {
-      futures.emplace_back(std::async(std::launch::async, worker, batch));
-    }
-  }
-
-  // Merge results
-  for (auto& future : futures) {
-    if (stop_token.stop_requested()) {
-      break;
-    }
-    ScanStorage result = future.get();
-    storage.addresses.insert(storage.addresses.end(),
-                             result.addresses.begin(),
-                             result.addresses.end());
-    storage.curr_raw.insert(
-        storage.curr_raw.end(), result.curr_raw.begin(), result.curr_raw.end());
-  }
-
-  if (stop_token.stop_requested()) {
-    is_scanning_ = false;
-    LogInfo("Scan cancelled.");
-    return;
-  }
-
-  // Store result for main thread
-  {
-    std::scoped_lock lock(pending_mutex_);
-    pending_storage_ = std::move(storage);
-    scan_finished_flag_ = true;
-  }
-}
-
-void ScanResultModel::CancelScan() {
-  if (is_scanning_.load()) {
-    task_runner_->RequestStop();
-  }
-}
-
-void ScanResultModel::ApplyPendingResult() {
-  if (!scan_finished_flag_.load()) {
-    return;
-  }
-
-  std::scoped_lock lock(mutex_, pending_mutex_);
-
-  // Initialize previous values with current to create baseline
-  pending_storage_.prev_raw = pending_storage_.curr_raw;
-
-  scan_storage_ = std::move(pending_storage_);
-  scan_finished_flag_ = false;
-  is_scanning_ = false;
-
-  // Clear pending storage to free memory
-  ClearStorage(pending_storage_);
-
-  signals_.memory_changed.publish(scan_storage_);
-  LogInfo("Scan complete. Found {} addresses.", scan_storage_.addresses.size());
+  pending_scan_ = scanner_.FirstScanAsync(
+      *active_process_, config, stop_source_.get_token(), [this](float p) {
+        progress_ = p;
+      });
 }
 
 void ScanResultModel::NextScan() {
   if (is_scanning_.load()) {
-    return;
-  }
-
-  std::scoped_lock lock(mutex_);
-
-  std::optional<ScopedProcessSuspend> suspend;
-  if (pause_while_scanning_enabled_) {
-    suspend.emplace(active_process_);
-  }
-
-  if (scan_storage_.addresses.empty()) {
     return;
   }
 
@@ -511,232 +91,99 @@ void ScanResultModel::NextScan() {
     return;
   }
 
-  // We deliberately do NOT move curr_raw to prev_raw here.
-  // prev_raw contains the clean snapshot from the LAST scan, while curr_raw
-  // might have been modified by the auto-update thread. We compare
-  // Live (Freshly Read) vs Snapshot (Clean) to avoid logic errors.
-
-  const size_t count = scan_storage_.addresses.size();
-  const size_t stride = scan_storage_.stride;
-
-  if (count == 0 || stride == 0) {
+  if (!session_->HasResults()) {
+    LogWarning("No previous results to filter.");
     return;
   }
 
-  // Reading all addresses in one go stops the app from freezing due to too
-  // many system calls.
-  std::vector<std::byte> current_memory_buffer(count * stride);
-  std::vector<uint8_t> success_mask(count, 0);
-
-  if (!active_process_->ReadMemory(scan_storage_.addresses,
-                                   stride,
-                                   current_memory_buffer,
-                                   &success_mask)) {
-    LogWarning("Failed to read memory batch during next scan.");
+  core::ScanConfig config = BuildScanConfig(true);
+  if (!config.Validate()) {
+    LogWarning("Invalid scan configuration.");
     return;
   }
 
-  // Building a new vector is faster than removing items from the middle of
-  // an existing one.
+  LogInfo("Starting next scan...");
+  is_scanning_ = true;
+  progress_ = 0.0f;
+  stop_source_ = std::stop_source{};
+  pending_config_ = config;
 
-  ScanStorage filtered_storage;
-  filtered_storage.stride = stride;
-  filtered_storage.value_type = scan_storage_.value_type;
-  filtered_storage.addresses.reserve(count / 2);
+  // Launch async immediately. The snapshot is taken on the background thread
+  // to avoid blocking the UI.
+  pending_scan_ = std::async(
+      std::launch::async,
+      [this, config, stop_token = stop_source_.get_token()]() {
+        ScanStorage snapshot = session_->GetStorageSnapshot();
+        return scanner_.NextScan(
+            *active_process_, config, snapshot, stop_token, [this](float p) {
+              progress_ = p;
+            });
+      });
+}
 
-  filtered_storage.curr_raw.reserve((count / 2) * stride);
-  filtered_storage.prev_raw.reserve((count / 2) * stride);
+bool ScanResultModel::HasPendingResult() const {
+  if (!pending_scan_.valid()) {
+    return false;
+  }
+  return pending_scan_.wait_for(std::chrono::seconds(0)) ==
+         std::future_status::ready;
+}
 
-  // Define logic here to keep the loop clean.
-  const auto check_condition = [&](std::span<const std::byte> curr,
-                                   std::span<const std::byte> prev,
-                                   size_t index) -> bool {
-    // If we failed to read this address, we simply discard it.
-    if (index < success_mask.size() && success_mask[index] == 0) {
-      return false;
-    }
+void ScanResultModel::WaitForScanToFinish() {
+  if (pending_scan_.valid()) {
+    pending_scan_.wait();
+  }
+}
 
-    switch (scan_comparison_) {
-      case ScanComparison::kChanged:
-
-        return IsValueChanged(curr, prev);
-      case ScanComparison::kUnchanged:
-        return !IsValueChanged(curr, prev);
-
-      case ScanComparison::kIncreased:
-        return DispatchScanType(scan_value_type_, [&]<typename T>() {
-          return IsValueIncreased<T>(curr, prev);
-        });
-
-      case ScanComparison::kDecreased:
-        return DispatchScanType(scan_value_type_, [&]<typename T>() {
-          return IsValueDecreased<T>(curr, prev);
-        });
-
-      case ScanComparison::kIncreasedBy:
-        return DispatchScanType(scan_value_type_, [&]<typename T>() {
-          return IsValueIncreasedBy<T>(
-              curr, prev, std::span{target_scan_value_});
-        });
-
-      case ScanComparison::kDecreasedBy:
-        return DispatchScanType(scan_value_type_, [&]<typename T>() {
-          return IsValueDecreasedBy<T>(
-              curr, prev, std::span{target_scan_value_});
-        });
-
-      case ScanComparison::kExactValue:
-        return std::ranges::equal(curr, target_scan_value_);
-
-      default:
-        return false;
-    }
-  };
-
-  if (scan_storage_.prev_raw.size() != count * stride) {
-    LogWarning("Mismatch in previous raw data size. Aborting NextScan.");
+void ScanResultModel::ApplyPendingResult() {
+  if (!pending_scan_.valid()) {
     return;
   }
 
-  // --- Optimization: Use SIMD for NextScan ---
-  if (scan_comparison_ == ScanComparison::kExactValue) {
-    auto callback = [&](size_t offset) {
-      if (offset % stride != 0) {
-        return;
-      }
-      const size_t index = offset / stride;
-      if (index >= count) {
-        return;
-      }
-      if (index < success_mask.size() && success_mask[index] == 0) {
-        return;
-      }
-
-      filtered_storage.addresses.emplace_back(scan_storage_.addresses[index]);
-      const auto val_start = current_memory_buffer.begin() + offset;
-      filtered_storage.curr_raw.insert(
-          filtered_storage.curr_raw.end(), val_start, val_start + stride);
-      filtered_storage.prev_raw.insert(
-          filtered_storage.prev_raw.end(), val_start, val_start + stride);
-    };
-
-    if (target_scan_mask_.empty()) {
-      LogInfo("NextScan: ExactValue (Scalar/SIMD) stride={}", stride);
-      core::ScanBuffer(
-          current_memory_buffer, target_scan_value_, stride, callback);
-    } else {
-      LogInfo("NextScan: ExactValue (Masked SIMD) stride={}", stride);
-      core::ScanBufferMasked(current_memory_buffer,
-                             target_scan_value_,
-                             target_scan_mask_,
-                             callback);
-    }
-  } else if (scan_comparison_ == ScanComparison::kChanged ||
-             scan_comparison_ == ScanComparison::kUnchanged) {
-    const bool find_equal = (scan_comparison_ == ScanComparison::kUnchanged);
-    core::ScanMemCmp(
-        current_memory_buffer,
-        scan_storage_.prev_raw,
-        find_equal,
-        stride,
-        [&](size_t offset) {
-          const size_t index = offset / stride;
-          if (index >= count) {
-            return;
-          }
-          if (index < success_mask.size() && success_mask[index] == 0) {
-            return;
-          }
-
-          filtered_storage.addresses.emplace_back(
-              scan_storage_.addresses[index]);
-
-          const auto val_start = current_memory_buffer.begin() + offset;
-
-          filtered_storage.curr_raw.insert(
-              filtered_storage.curr_raw.end(), val_start, val_start + stride);
-
-          // Update baseline
-          filtered_storage.prev_raw.insert(
-              filtered_storage.prev_raw.end(), val_start, val_start + stride);
-        });
-  } else if ((scan_comparison_ == ScanComparison::kIncreased ||
-              scan_comparison_ == ScanComparison::kDecreased) &&
-             (scan_value_type_ == ScanValueType::kInt32 ||
-              scan_value_type_ == ScanValueType::kFloat)) {
-    // --- Optimization: Use SIMD for Increased/Decreased (Int32/Float only) ---
-    const bool greater = (scan_comparison_ == ScanComparison::kIncreased);
-
-    auto callback = [&](size_t offset) {
-      const size_t index = offset / stride;
-      if (index >= count) {
-        return;
-      }
-      if (index < success_mask.size() && success_mask[index] == 0) {
-        return;
-      }
-
-      filtered_storage.addresses.emplace_back(scan_storage_.addresses[index]);
-      const auto val_start = current_memory_buffer.begin() + offset;
-      filtered_storage.curr_raw.insert(
-          filtered_storage.curr_raw.end(), val_start, val_start + stride);
-      filtered_storage.prev_raw.insert(
-          filtered_storage.prev_raw.end(), val_start, val_start + stride);
-    };
-
-    if (scan_value_type_ == ScanValueType::kInt32) {
-      if (greater) {
-        core::ScanMemCompareGreater<int32_t>(
-            current_memory_buffer, scan_storage_.prev_raw, callback);
-      } else {
-        core::ScanMemCompareGreater<int32_t>(
-            scan_storage_.prev_raw, current_memory_buffer, callback);
-      }
-    } else {
-      if (greater) {
-        core::ScanMemCompareGreater<float>(
-            current_memory_buffer, scan_storage_.prev_raw, callback);
-      } else {
-        core::ScanMemCompareGreater<float>(
-            scan_storage_.prev_raw, current_memory_buffer, callback);
-      }
-    }
-  } else {
-    // --- Standard Scalar Loop for other comparisons ---
-    PerformNextScanScalar(current_memory_buffer,
-                          scan_storage_,
-                          count,
-                          stride,
-                          filtered_storage,
-                          check_condition);
+  if (pending_scan_.wait_for(std::chrono::seconds(0)) !=
+      std::future_status::ready) {
+    return;
   }
 
-  scan_storage_ = std::move(filtered_storage);
-  signals_.memory_changed.publish(scan_storage_);
+  core::ScanResult result = pending_scan_.get();
+  is_scanning_ = false;
 
-  LogInfo("Next scan complete. {} addresses remaining.",
-          scan_storage_.addresses.size());
+  if (!result.success) {
+    LogWarning("Scan failed: {}", result.error_message);
+    return;
+  }
+
+  session_->CommitResults(std::move(result.storage), pending_config_);
+  signals_.memory_changed.publish(session_->GetStorageUnsafe());
+
+  LogInfo("Scan complete. Found {} addresses.", session_->GetResultCount());
+}
+
+void ScanResultModel::CancelScan() {
+  if (is_scanning_.load()) {
+    stop_source_.request_stop();
+  }
 }
 
 void ScanResultModel::UpdateCurrentValues() {
-  std::scoped_lock lock(mutex_);
-
-  if (scan_storage_.addresses.empty() || !CanScan(active_process_)) {
+  if (!CanScan(active_process_)) {
     return;
   }
 
-  // We assert now to avoid issues if the list size changed but the buffer
-  // did not catch up yet. If for any reason this happens, this should be fixed.
-  const size_t required_size =
-      scan_storage_.addresses.size() * scan_storage_.stride;
-  Assert(scan_storage_.curr_raw.size() == required_size);
-
-  bool success = active_process_->ReadMemory(
-      scan_storage_.addresses, scan_storage_.stride, scan_storage_.curr_raw);
-
-  if (success) {
-    signals_.memory_changed.publish(scan_storage_);
+  ScanStorage snapshot = session_->GetStorageSnapshot();
+  if (snapshot.addresses.empty()) {
+    return;
   }
+
+  std::vector<std::byte> new_values(snapshot.addresses.size() *
+                                    snapshot.stride);
+  if (!active_process_->ReadMemory(
+          snapshot.addresses, snapshot.stride, new_values)) {
+    return;
+  }
+
+  session_->UpdateCurrentValues(std::move(new_values));
+  signals_.memory_changed.publish(session_->GetStorageUnsafe());
 }
 
 void ScanResultModel::SetActiveProcess(IProcess* process) {
@@ -751,9 +198,8 @@ void ScanResultModel::SetActiveProcess(IProcess* process) {
 }
 
 void ScanResultModel::Clear() {
-  std::scoped_lock lock(mutex_);
-  ClearStorage(scan_storage_);
-  signals_.memory_changed.publish(scan_storage_);
+  session_->Clear();
+  signals_.memory_changed.publish(session_->GetStorageUnsafe());
 }
 
 void ScanResultModel::StartAutoUpdate() {
@@ -761,28 +207,25 @@ void ScanResultModel::StartAutoUpdate() {
     return;
   }
 
-  task_ = std::jthread([this](std::stop_token stop_token) {
-    while (!stop_token.stop_requested()) {
-      // We limit updates to 10k items because refreshing millions freezes the
-      // UI.
-      size_t count = 0;
-      {
-        std::scoped_lock lock(mutex_);
-        count = scan_storage_.addresses.size();
-      }
-
-      if (count > 0 && count < 10000) {
-        UpdateCurrentValues();
-      }
-      std::this_thread::sleep_for(std::chrono::milliseconds(500));
-    }
-  });
+  task_ = std::jthread(
+      [this](std::stop_token stop_token) { AutoUpdateLoop(stop_token); });
 }
 
 void ScanResultModel::StopAutoUpdate() {
   if (task_.joinable()) {
     task_.request_stop();
     task_.join();
+  }
+}
+
+void ScanResultModel::AutoUpdateLoop(std::stop_token stop_token) {
+  while (!stop_token.stop_requested()) {
+    size_t count = session_->GetResultCount();
+
+    if (count > 0 && count < 10000) {
+      UpdateCurrentValues();
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
   }
 }
 

--- a/src/maia/application/scan_result_model_test.cpp
+++ b/src/maia/application/scan_result_model_test.cpp
@@ -5,12 +5,9 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-#include <chrono>
 #include <cstring>
-#include <thread>
 #include <vector>
 
-#include "maia/core/task_runner.h"
 #include "maia/tests/fake_process.h"
 
 namespace maia {
@@ -20,14 +17,25 @@ class ScanResultModelTest : public ::testing::Test {
  protected:
   void SetUp() override {
     process_ = std::make_unique<test::FakeProcess>(1024);
-    auto runner = std::make_unique<core::SyncTaskRunner>();
-    model_ = std::make_unique<ScanResultModel>(std::move(runner));
+    model_ = std::make_unique<ScanResultModel>();
     model_->SetActiveProcess(process_.get());
     model_->StopAutoUpdate();
   }
 
   void TearDown() override {
-    model_->Clear();
+    if (model_) {
+      model_->Clear();
+    }
+  }
+
+  void WaitForScanComplete() {
+    model_->WaitForScanToFinish();
+    model_->ApplyPendingResult();
+  }
+
+  void Scan() {
+    model_->FirstScan();
+    WaitForScanComplete();
   }
 
   template <typename T>
@@ -41,34 +49,21 @@ class ScanResultModelTest : public ::testing::Test {
   std::unique_ptr<test::FakeProcess> process_;
 };
 
-// Fixture for logic tests that need smaller chunks
 class ScanResultModelLogicTest : public ScanResultModelTest {
  protected:
   void SetUp() override {
-    // Use 4KB chunks for granular testing without massive memory usage.
-    model_ = std::make_unique<ScanResultModel>(
-        std::make_unique<core::SyncTaskRunner>(), 4096);
-
-    // Small process (8KB) is sufficient for logic tests.
+    model_ = std::make_unique<ScanResultModel>(4096);
     process_ = std::make_unique<test::FakeProcess>(8192);
     model_->SetActiveProcess(process_.get());
     model_->StopAutoUpdate();
   }
-
-  void Scan() {
-    model_->FirstScan();
-    model_->ApplyPendingResult();
-  }
 };
 
-// Fixture for tests that verify chunking behavior with large memory
 class ScanResultModelChunkedTest : public ScanResultModelTest {
  protected:
   void SetUp() override {
-    // 40MB to safely cover 32MB chunk boundary
     process_ = std::make_unique<test::FakeProcess>(40 * 1024 * 1024);
-    model_ = std::make_unique<ScanResultModel>(
-        std::make_unique<core::SyncTaskRunner>());
+    model_ = std::make_unique<ScanResultModel>();
     model_->SetActiveProcess(process_.get());
     model_->StopAutoUpdate();
   }
@@ -84,8 +79,7 @@ TEST_F(ScanResultModelTest, FirstScanExactValueFindsMatches) {
   model_->SetScanComparison(ScanComparison::kExactValue);
   model_->SetTargetScanValue(ToBytes<uint32_t>(42));
 
-  model_->FirstScan();
-  model_->ApplyPendingResult();
+  Scan();
 
   const auto& storage = model_->entries();
   ASSERT_EQ(storage.addresses.size(), 2);
@@ -101,11 +95,9 @@ TEST_F(ScanResultModelTest, FirstScanUnknownValueSnapshotsMemory) {
   process_->WriteValue<uint32_t>(0, 10);
   model_->SetScanComparison(ScanComparison::kUnknown);
 
-  model_->FirstScan();
-  model_->ApplyPendingResult();
+  Scan();
 
   const auto& entries = model_->entries();
-  // 1KB / 4 bytes = ~256 potential alignments
   EXPECT_GT(entries.addresses.size(), 250);
 
   uint32_t val0 = *reinterpret_cast<const uint32_t*>(entries.curr_raw.data());
@@ -117,13 +109,13 @@ TEST_F(ScanResultModelTest, NextScanIncreasedValueFiltersResults) {
   process_->WriteValue<uint32_t>(200, 50);
 
   model_->SetScanComparison(ScanComparison::kUnknown);
-  model_->FirstScan();
-  model_->ApplyPendingResult();
+  Scan();
 
-  process_->WriteValue<uint32_t>(100, 15);  // Increased
+  process_->WriteValue<uint32_t>(100, 15);
 
   model_->SetScanComparison(ScanComparison::kIncreased);
   model_->NextScan();
+  WaitForScanComplete();
 
   const auto& entries = model_->entries();
 
@@ -144,20 +136,19 @@ TEST_F(ScanResultModelTest, NextScanIncreasedValueFiltersResults) {
 }
 
 TEST_F(ScanResultModelTest, NextScanExactValueFiltersResults) {
-  // Use aligned offsets (divisible by 4 for uint32_t)
   process_->WriteValue<uint32_t>(16, 100);
   process_->WriteValue<uint32_t>(32, 100);
 
   model_->SetScanComparison(ScanComparison::kExactValue);
   model_->SetTargetScanValue(ToBytes<uint32_t>(100));
-  model_->FirstScan();
-  model_->ApplyPendingResult();
+  Scan();
 
   ASSERT_EQ(model_->entries().addresses.size(), 2);
 
   process_->WriteValue<uint32_t>(32, 101);
 
   model_->NextScan();
+  WaitForScanComplete();
 
   const auto& entries = model_->entries();
   ASSERT_EQ(entries.addresses.size(), 1);
@@ -181,13 +172,12 @@ TEST_F(ScanResultModelTest, SignalEmittedOnScan) {
       model_->sinks().MemoryChanged().connect<&TestListener::OnMemoryChanged>(
           listener);
 
-  process_->WriteValue<uint32_t>(16, 999);  // Aligned offset
+  process_->WriteValue<uint32_t>(16, 999);
 
   model_->SetScanComparison(ScanComparison::kExactValue);
   model_->SetTargetScanValue(ToBytes<uint32_t>(999));
 
-  model_->FirstScan();
-  model_->ApplyPendingResult();
+  Scan();
 
   EXPECT_TRUE(listener.signal_received);
   EXPECT_EQ(listener.received_count, 1);
@@ -197,17 +187,14 @@ TEST_F(ScanResultModelTest, InvalidProcessDoesNothing) {
   process_->SetValid(false);
   model_->SetScanComparison(ScanComparison::kUnknown);
   model_->FirstScan();
-  // Wait a bit for the early exit path
-  std::this_thread::sleep_for(std::chrono::milliseconds(10));
-  // No pending result for invalid process
+  EXPECT_FALSE(model_->IsScanning());
   EXPECT_TRUE(model_->entries().addresses.empty());
 }
 
 TEST_F(ScanResultModelTest, ClearResetsStorage) {
   process_->WriteValue<uint32_t>(0, 123);
   model_->SetScanComparison(ScanComparison::kUnknown);
-  model_->FirstScan();
-  model_->ApplyPendingResult();
+  Scan();
   ASSERT_FALSE(model_->entries().addresses.empty());
 
   model_->Clear();
@@ -220,12 +207,12 @@ TEST_F(ScanResultModelTest, NextScanPopulatesPreviousValues) {
   process_->WriteValue<uint32_t>(100, 10);
 
   model_->SetScanComparison(ScanComparison::kUnknown);
-  model_->FirstScan();
-  model_->ApplyPendingResult();
+  Scan();
 
   process_->WriteValue<uint32_t>(100, 20);
   model_->SetScanComparison(ScanComparison::kChanged);
   model_->NextScan();
+  WaitForScanComplete();
 
   const auto& entries = model_->entries();
   ASSERT_FALSE(entries.addresses.empty());
@@ -242,35 +229,27 @@ TEST_F(ScanResultModelTest, NextScanPopulatesPreviousValues) {
 }
 
 TEST_F(ScanResultModelTest, NextScanPreservesSnapshotAgainstAutoUpdate) {
-  // Setup Initial State (Value = 10)
-  // We use a specific address to ensure deterministic behavior.
   constexpr uintptr_t kAddressOffset = 0x10;
   process_->WriteValue<uint32_t>(kAddressOffset, 10);
 
   model_->SetScanComparison(ScanComparison::kUnknown);
-  model_->FirstScan();
-  model_->ApplyPendingResult();
+  Scan();
 
-  // Sanity check: verify we found the initial value.
   ASSERT_FALSE(model_->entries().addresses.empty());
 
-  // Change the value in RAM (Value = 20).
   process_->WriteValue<uint32_t>(kAddressOffset, 20);
 
-  // TRIGGER THE BUG SCENARIO (Simulate Auto-Update)
   model_->UpdateCurrentValues();
 
-  // Perform Next Scan (Looking for "Changed" values).
   model_->SetScanComparison(ScanComparison::kChanged);
   model_->NextScan();
+  WaitForScanComplete();
 
-  // Assertions
   EXPECT_FALSE(model_->entries().addresses.empty())
       << "Entry incorrectly removed! NextScan likely compared against the "
          "auto-updated value instead of the snapshot.";
 
   if (!model_->entries().addresses.empty()) {
-    // Verify the model updated its values correctly after the successful scan
     const auto& entries = model_->entries();
     uint32_t current_val =
         *reinterpret_cast<const uint32_t*>(entries.curr_raw.data());
@@ -285,69 +264,57 @@ TEST_F(ScanResultModelTest, NextScanPreservesSnapshotAgainstAutoUpdate) {
 
 TEST_F(ScanResultModelTest,
        BugReproductionChangedFirstScanThenChangedNextScan) {
-  // Setup Initial State (Value = 10)
   process_->WriteValue<uint32_t>(100, 10);
 
-  // User selects "Changed" for the First Scan.
   model_->SetScanComparison(ScanComparison::kChanged);
 
-  // Execute First Scan
-  model_->FirstScan();
-  model_->ApplyPendingResult();
+  Scan();
 
-  // Verify First Scan behaved like "Unknown" (snapshot everything)
   ASSERT_FALSE(model_->entries().addresses.empty());
 
-  // Change Value in RAM (Value = 20)
   process_->WriteValue<uint32_t>(100, 20);
 
-  // Execute Next Scan
   model_->NextScan();
+  WaitForScanComplete();
 
-  // Verify Result. Should find the address because 20 != 10.
   EXPECT_FALSE(model_->entries().addresses.empty());
 }
 
 TEST_F(ScanResultModelTest, NextScanIncreasedByFindsMatch) {
   process_->WriteValue<uint32_t>(100, 10);
   model_->SetScanComparison(ScanComparison::kUnknown);
-  model_->FirstScan();
-  model_->ApplyPendingResult();
+  Scan();
 
-  // Increase by 3 (10 -> 13)
   process_->WriteValue<uint32_t>(100, 13);
 
   model_->SetScanComparison(ScanComparison::kIncreasedBy);
   model_->SetTargetScanValue(ToBytes<uint32_t>(3));
   model_->NextScan();
+  WaitForScanComplete();
 
   const auto& entries = model_->entries();
   ASSERT_FALSE(entries.addresses.empty());
   EXPECT_EQ(entries.addresses[0], 0x100000 + 100);
 
-  // Verify value
   uint32_t val = *reinterpret_cast<const uint32_t*>(entries.curr_raw.data());
   EXPECT_EQ(val, 13);
 }
 
 TEST_F(ScanResultModelTest, NextScanGracefullyHandlesInvalidMemory) {
-  // 1. Setup: First Scan finds 2 values
   process_->WriteValue<uint32_t>(100, 42);
   process_->WriteValue<uint32_t>(200, 42);
 
   model_->SetScanComparison(ScanComparison::kExactValue);
   model_->SetTargetScanValue(ToBytes<uint32_t>(42));
-  model_->FirstScan();
-  model_->ApplyPendingResult();
+  Scan();
 
   ASSERT_EQ(model_->entries().addresses.size(), 2);
 
-  // 2. Scenario: One address becomes invalid (e.g. unmapped page)
   process_->MarkAddressInvalid(0x100000 + 100);
 
-  // 3. Action: Next Scan (Unchanged)
   model_->SetScanComparison(ScanComparison::kUnchanged);
   model_->NextScan();
+  WaitForScanComplete();
 
   const auto& entries = model_->entries();
   ASSERT_EQ(entries.addresses.size(), 1);
@@ -355,15 +322,12 @@ TEST_F(ScanResultModelTest, NextScanGracefullyHandlesInvalidMemory) {
 }
 
 TEST_F(ScanResultModelTest, FirstScanAobFindsMatches) {
-  // Write a pattern: AA BB CC DD EE
   uint8_t pattern[] = {0xAA, 0xBB, 0xCC, 0xDD, 0xEE};
   std::memcpy(process_->GetRawMemory().data() + 300, pattern, 5);
 
-  // Write a similar pattern with one byte different: AA BB 00 DD EE
   uint8_t noisy[] = {0xAA, 0xBB, 0x00, 0xDD, 0xEE};
   std::memcpy(process_->GetRawMemory().data() + 600, noisy, 5);
 
-  // Scan for AA BB ?? DD EE
   std::vector<std::byte> val = {std::byte{0xAA},
                                 std::byte{0xBB},
                                 std::byte{0x00},
@@ -379,11 +343,9 @@ TEST_F(ScanResultModelTest, FirstScanAobFindsMatches) {
   model_->SetScanValueType(ScanValueType::kArrayOfBytes);
   model_->SetTargetScanPattern(val, mask);
 
-  model_->FirstScan();
-  model_->ApplyPendingResult();
+  Scan();
 
   const auto& storage = model_->entries();
-  // Should find BOTH 300 and 600 because of the wildcard
   EXPECT_EQ(storage.stride, 5);
 }
 
@@ -391,7 +353,6 @@ TEST_F(ScanResultModelTest, FirstScanStringWithSpacesFindsMatches) {
   const char* text = "hello world";
   std::memcpy(process_->GetRawMemory().data() + 400, text, std::strlen(text));
 
-  // Search for "hello wor"
   std::string search = "hello wor";
   std::vector<std::byte> val;
   for (char c : search) {
@@ -402,8 +363,7 @@ TEST_F(ScanResultModelTest, FirstScanStringWithSpacesFindsMatches) {
   model_->SetScanValueType(ScanValueType::kString);
   model_->SetTargetScanValue(val);
 
-  model_->FirstScan();
-  model_->ApplyPendingResult();
+  Scan();
 
   const auto& storage = model_->entries();
   ASSERT_EQ(storage.addresses.size(), 1);
@@ -417,7 +377,6 @@ TEST_F(ScanResultModelTest, FirstScanStringWithSpacesAtUnalignedAddress) {
       process_->GetRawMemory().data(), 0, process_->GetRawMemory().size());
   std::memcpy(process_->GetRawMemory().data() + 401, text, std::strlen(text));
 
-  // Search for "hello wor"
   std::string search = "hello wor";
   std::vector<std::byte> val;
   for (char c : search) {
@@ -428,8 +387,7 @@ TEST_F(ScanResultModelTest, FirstScanStringWithSpacesAtUnalignedAddress) {
   model_->SetScanValueType(ScanValueType::kString);
   model_->SetTargetScanValue(val);
 
-  model_->FirstScan();
-  model_->ApplyPendingResult();
+  Scan();
 
   const auto& storage = model_->entries();
   ASSERT_EQ(storage.addresses.size(), 1);
@@ -440,8 +398,7 @@ TEST_F(ScanResultModelTest, FirstScanStringWithSpacesAtUnalignedAddress) {
 
 TEST_F(ScanResultModelLogicTest,
        UnknownScanFindsUnalignedWhenFastScanDisabled) {
-  // For unknown scan, disabling fast scan should snapshot EVERY byte.
-  model_->SetFastScan(false);  // DISABLE FAST SCAN
+  model_->SetFastScan(false);
   model_->SetScanComparison(ScanComparison::kUnknown);
 
   Scan();
@@ -449,46 +406,30 @@ TEST_F(ScanResultModelLogicTest,
   const auto& storage = model_->entries();
   const uintptr_t base = process_->GetBaseAddress();
 
-  // With alignment=1, we should find matches at 0, 1, 2, 3, 4, ...
-  // For 8192 bytes, we expect roughly 8192-3 addresses (for uint32 size).
   ASSERT_GT(storage.addresses.size(), 8000);
   EXPECT_EQ(storage.addresses[0], base + 0);
   EXPECT_EQ(storage.addresses[1], base + 1);
   EXPECT_EQ(storage.addresses[2], base + 2);
   EXPECT_EQ(storage.addresses[3], base + 3);
 
-  // Verify stride is correct
   EXPECT_EQ(storage.stride, sizeof(uint32_t));
 }
 
 TEST_F(ScanResultModelLogicTest, UnknownScanSnapshotsAcrossChunks) {
-  // Verifies that Unknown scan snapshots data correctly across chunk
-  // boundaries. Configuration from SetUp:
-  // - Process Memory: 8192 bytes (8KB)
-  // - Chunk Size:     4096 bytes (4KB)
-  // - Result:         Exactly 2 chunks. Boundary is at offset 4096.
-
   model_->SetScanComparison(ScanComparison::kUnknown);
   Scan();
 
   const auto& storage = model_->entries();
   const uintptr_t base = process_->GetBaseAddress();
 
-  // Total expected items: 8192 / 4 = 2048 uint32_t values.
   ASSERT_EQ(storage.addresses.size(), 2048);
 
-  // --- Verify Chunk 1 (Offsets 0 to 4092) ---
   EXPECT_EQ(storage.addresses[0], base + 0);
-  // Last item of Chunk 1 (4096 - 4)
   EXPECT_EQ(storage.addresses[1023], base + 4092);
 
-  // --- Verify Chunk 2 (Offsets 4096 to 8188) ---
-  // First item of Chunk 2 (Boundary)
   EXPECT_EQ(storage.addresses[1024], base + 4096);
-  // Last item of Chunk 2
   EXPECT_EQ(storage.addresses[2047], base + 8188);
 
-  // Verify the list is contiguous (no gaps at boundary)
   for (size_t i = 0; i < storage.addresses.size(); ++i) {
     EXPECT_EQ(storage.addresses[i], base + (i * 4))
         << "Gap found at index " << i;
@@ -498,27 +439,23 @@ TEST_F(ScanResultModelLogicTest, UnknownScanSnapshotsAcrossChunks) {
 // --- Chunked Tests ---
 
 TEST_F(ScanResultModelChunkedTest, FindsMatchCrossingChunkBoundary) {
-  constexpr size_t kChunkSize = 32 * 1024 * 1024;  // 32MB
+  constexpr size_t kChunkSize = 32 * 1024 * 1024;
 
-  // Place a 4-byte value near the chunk boundary at an aligned offset.
-  const size_t near_boundary_offset = kChunkSize - 4;  // Aligned to 4
+  const size_t near_boundary_offset = kChunkSize - 4;
   const uint32_t magic_value = 0xDEADBEEF;
 
   process_->WriteValue<uint32_t>(near_boundary_offset, magic_value);
 
-  // Also place values well before and well after the boundary
   process_->WriteValue<uint32_t>(100, magic_value);
   process_->WriteValue<uint32_t>(kChunkSize + 100, magic_value);
 
   model_->SetScanComparison(ScanComparison::kExactValue);
   model_->SetTargetScanValue(ToBytes<uint32_t>(magic_value));
 
-  model_->FirstScan();
-  model_->ApplyPendingResult();
+  Scan();
 
   const auto& storage = model_->entries();
 
-  // Should find all 3 matches
   ASSERT_EQ(storage.addresses.size(), 3);
 
   bool found_near_boundary = false;
@@ -535,39 +472,32 @@ TEST_F(ScanResultModelChunkedTest, FindsMatchCrossingChunkBoundary) {
 }
 
 TEST_F(ScanResultModelChunkedTest, ExactScanSkipsUnalignedAddresses) {
-  // This test verifies that the full scan pipeline respects alignment.
   const uint32_t magic_value = 0xCAFEBABE;
 
-  // Place value at aligned offsets (divisible by 4)
-  process_->WriteValue<uint32_t>(0, magic_value);     // Aligned
-  process_->WriteValue<uint32_t>(100, magic_value);   // Aligned
-  process_->WriteValue<uint32_t>(1000, magic_value);  // Aligned
+  process_->WriteValue<uint32_t>(0, magic_value);
+  process_->WriteValue<uint32_t>(100, magic_value);
+  process_->WriteValue<uint32_t>(1000, magic_value);
 
-  // Place value at unaligned offsets (NOT divisible by 4)
-  process_->WriteValue<uint32_t>(201, magic_value);  // Unaligned
-  process_->WriteValue<uint32_t>(307, magic_value);  // Unaligned
-  process_->WriteValue<uint32_t>(503, magic_value);  // Unaligned
+  process_->WriteValue<uint32_t>(201, magic_value);
+  process_->WriteValue<uint32_t>(307, magic_value);
+  process_->WriteValue<uint32_t>(503, magic_value);
 
   model_->SetScanComparison(ScanComparison::kExactValue);
   model_->SetTargetScanValue(ToBytes<uint32_t>(magic_value));
 
-  model_->FirstScan();
-  model_->ApplyPendingResult();
+  Scan();
 
   const auto& storage = model_->entries();
   uintptr_t base = process_->GetBaseAddress();
 
-  // Should find exactly 3 matches (only aligned ones)
   ASSERT_EQ(storage.addresses.size(), 3)
       << "Should only find aligned matches, not unaligned ones";
 
-  // Verify all found addresses are aligned
   for (auto addr : storage.addresses) {
     size_t offset = addr - base;
     EXPECT_EQ(offset % 4, 0) << "Found unaligned address at offset " << offset;
   }
 
-  // Verify specific aligned offsets were found
   EXPECT_EQ(storage.addresses[0], base + 0);
   EXPECT_EQ(storage.addresses[1], base + 100);
   EXPECT_EQ(storage.addresses[2], base + 1000);
@@ -576,7 +506,6 @@ TEST_F(ScanResultModelChunkedTest, ExactScanSkipsUnalignedAddresses) {
 TEST_F(ScanResultModelChunkedTest, ExactScanUnalignedOnlyFindsNothing) {
   const uint32_t magic_value = 0xDEADC0DE;
 
-  // Place values ONLY at unaligned offsets
   process_->WriteValue<uint32_t>(101, magic_value);
   process_->WriteValue<uint32_t>(205, magic_value);
   process_->WriteValue<uint32_t>(309, magic_value);
@@ -585,39 +514,33 @@ TEST_F(ScanResultModelChunkedTest, ExactScanUnalignedOnlyFindsNothing) {
   model_->SetScanComparison(ScanComparison::kExactValue);
   model_->SetTargetScanValue(ToBytes<uint32_t>(magic_value));
 
-  model_->FirstScan();
-  model_->ApplyPendingResult();
+  Scan();
 
   const auto& storage = model_->entries();
 
-  // Should find nothing because all values are at unaligned offsets
   EXPECT_EQ(storage.addresses.size(), 0)
       << "Should not find any matches when all are unaligned";
 }
 
 TEST_F(ScanResultModelChunkedTest, AlignmentAcrossChunkBoundary) {
-  constexpr size_t kChunkSize = 32 * 1024 * 1024;  // 32MB
+  constexpr size_t kChunkSize = 32 * 1024 * 1024;
   const uint32_t magic_value = 0xBEEFCAFE;
 
-  // Place aligned values in different chunks
-  process_->WriteValue<uint32_t>(0, magic_value);                 // Chunk 0
-  process_->WriteValue<uint32_t>(kChunkSize, magic_value);        // Chunk 1
-  process_->WriteValue<uint32_t>(kChunkSize + 100, magic_value);  // Chunk 1
+  process_->WriteValue<uint32_t>(0, magic_value);
+  process_->WriteValue<uint32_t>(kChunkSize, magic_value);
+  process_->WriteValue<uint32_t>(kChunkSize + 100, magic_value);
 
-  // Place unaligned values that should be skipped
-  process_->WriteValue<uint32_t>(kChunkSize + 201, magic_value);  // Unaligned
-  process_->WriteValue<uint32_t>(kChunkSize + 303, magic_value);  // Unaligned
+  process_->WriteValue<uint32_t>(kChunkSize + 201, magic_value);
+  process_->WriteValue<uint32_t>(kChunkSize + 303, magic_value);
 
   model_->SetScanComparison(ScanComparison::kExactValue);
   model_->SetTargetScanValue(ToBytes<uint32_t>(magic_value));
 
-  model_->FirstScan();
-  model_->ApplyPendingResult();
+  Scan();
 
   const auto& storage = model_->entries();
   uintptr_t base = process_->GetBaseAddress();
 
-  // Should find exactly 3 aligned matches across chunks
   ASSERT_EQ(storage.addresses.size(), 3);
   EXPECT_EQ(storage.addresses[0], base + 0);
   EXPECT_EQ(storage.addresses[1], base + kChunkSize);
@@ -628,23 +551,47 @@ TEST_F(ScanResultModelChunkedTest, FindsUnalignedWhenFastScanDisabled) {
   const uint32_t magic_value = 0xCAFEBABE;
   const uintptr_t base = process_->GetBaseAddress();
 
-  // Place value at unaligned offsets
   process_->WriteValue<uint32_t>(1, magic_value);
   process_->WriteValue<uint32_t>(13, magic_value);
 
-  model_->SetFastScan(false);  // DISABLE FAST SCAN
+  model_->SetFastScan(false);
   model_->SetScanComparison(ScanComparison::kExactValue);
   model_->SetTargetScanValue(ToBytes<uint32_t>(magic_value));
 
-  model_->FirstScan();
-  model_->ApplyPendingResult();
+  Scan();
 
   const auto& storage = model_->entries();
 
-  // Should now find BOTH unaligned matches
   ASSERT_EQ(storage.addresses.size(), 2);
   EXPECT_EQ(storage.addresses[0], base + 1);
   EXPECT_EQ(storage.addresses[1], base + 13);
+}
+
+TEST_F(ScanResultModelChunkedTest, DestructorDoesNotHangWhenScanning) {
+  model_->SetScanComparison(ScanComparison::kUnknown);
+  model_->FirstScan();
+  model_.reset();
+}
+
+TEST_F(ScanResultModelTest, CommittedConfigMatchesScanTimeSettings) {
+  process_->WriteValue<uint32_t>(100, 42);
+
+  model_->SetScanComparison(ScanComparison::kExactValue);
+  model_->SetTargetScanValue(ToBytes<uint32_t>(42));
+  model_->FirstScan();
+
+  model_->SetTargetScanValue(ToBytes<uint32_t>(99));
+
+  WaitForScanComplete();
+
+  core::ScanConfig committed_config = model_->GetSessionConfig();
+
+  ASSERT_EQ(committed_config.value.size(), sizeof(uint32_t));
+  uint32_t committed_value =
+      *reinterpret_cast<const uint32_t*>(committed_config.value.data());
+  EXPECT_EQ(committed_value, 42)
+      << "Committed config should use the value from scan start (42), not the "
+         "value changed mid-scan (99)";
 }
 
 }  // namespace

--- a/src/maia/core/CMakeLists.txt
+++ b/src/maia/core/CMakeLists.txt
@@ -15,6 +15,9 @@ target_sources(
         memory_common.h
         process.h
         pattern_parser.h
+        scan_config.h
+        scan_session.h
+        scanner.h
         simd_scanner.h
         scoped_process_suspend.h
   PRIVATE
@@ -22,6 +25,7 @@ target_sources(
     cpu_info.cpp
     process.cpp
     pattern_parser.cpp
+    scanner.cpp
     simd_scanner.cpp
 )
 

--- a/src/maia/core/scan_config.h
+++ b/src/maia/core/scan_config.h
@@ -1,0 +1,79 @@
+// Copyright (c) Maia
+
+#pragma once
+
+#include <cstddef>
+#include <vector>
+
+#include "maia/core/scan_types.h"
+
+namespace maia::core {
+
+/// \brief Immutable configuration for a memory scan operation.
+/// \details Consolidates all inputs required to perform a scan into a single
+/// struct. This enables clean APIs where the caller builds a config and passes
+/// it to the Scanner in one call, rather than setting state bit-by-bit.
+struct ScanConfig {
+  /// \brief The data type being scanned (e.g., Int32, Float).
+  ScanValueType value_type = ScanValueType::kUInt32;
+
+  /// \brief The comparison condition (e.g., ExactValue, GreaterThan).
+  ScanComparison comparison = ScanComparison::kUnknown;
+
+  /// \brief The primary value to search for.
+  /// \details Used for ExactValue, GreaterThan, LessThan, IncreasedBy, etc.
+  std::vector<std::byte> value;
+
+  /// \brief The secondary value for range searches.
+  /// \details Used only when comparison is kBetween or kNotBetween.
+  std::vector<std::byte> value_end;
+
+  /// \brief A bitmask for pattern matching.
+  /// \details Must be the same size as `value`. Bytes set to 0x00 are ignored
+  /// during comparison (wildcards).
+  std::vector<std::byte> mask;
+
+  /// \brief Memory alignment requirement.
+  /// \details 1 = Byte aligned (slow, thorough), 4 = 4-byte aligned (fast).
+  /// Typically matches the size of `value_type` for optimal performance.
+  size_t alignment = 4;
+
+  /// \brief Whether to use results from the previous scan.
+  /// \details If true, this is a "Next Scan" that filters existing results.
+  /// If false, this is a "First Scan" that searches all memory regions.
+  bool use_previous_results = false;
+
+  /// \brief Whether to suspend the target process during scanning.
+  bool pause_while_scanning = false;
+
+  /// \brief Validates the configuration for consistency.
+  /// \return true if the configuration is valid, false otherwise.
+  [[nodiscard]] bool Validate() const {
+    if (alignment == 0) {
+      return false;
+    }
+
+    size_t type_size = GetSizeForType(value_type);
+
+    // For fixed-size types, the value buffer must match the type size.
+    if (type_size > 0 && !value.empty() && value.size() != type_size) {
+      return false;
+    }
+
+    // Mask must match value size if provided.
+    if (!mask.empty() && mask.size() != value.size()) {
+      return false;
+    }
+
+    // Range comparisons require a second value.
+    if ((comparison == ScanComparison::kBetween ||
+         comparison == ScanComparison::kNotBetween) &&
+        value_end.empty()) {
+      return false;
+    }
+
+    return true;
+  }
+};
+
+}  // namespace maia::core

--- a/src/maia/core/scan_session.h
+++ b/src/maia/core/scan_session.h
@@ -1,0 +1,93 @@
+// Copyright (c) Maia
+
+#pragma once
+
+#include <shared_mutex>
+#include <vector>
+
+#include "maia/core/scan_config.h"
+#include "maia/core/scan_types.h"
+
+namespace maia::core {
+
+/// \brief Manages the state of a memory scanning session.
+/// \details The Session owns the scan results and the configuration that
+/// produced them. It provides thread-safe access for UI rendering (read) and
+/// scanner updates (write). This separation enables features like Undo/Redo
+/// and Save/Load in the future.
+class ScanSession {
+ public:
+  ScanSession() = default;
+  ~ScanSession() = default;
+
+  ScanSession(const ScanSession&) = delete;
+  ScanSession& operator=(const ScanSession&) = delete;
+  ScanSession(ScanSession&&) = delete;
+  ScanSession& operator=(ScanSession&&) = delete;
+
+  /// \brief Returns a snapshot of the current scan storage.
+  /// \details This is a copy, safe to use from the UI thread without holding
+  /// a lock for extended periods.
+  [[nodiscard]] ScanStorage GetStorageSnapshot() const {
+    std::shared_lock lock(mutex_);
+    return storage_;
+  }
+
+  /// \brief Returns a const reference to the storage (requires external sync).
+  /// \details Use this only when you need to avoid a copy and can guarantee
+  /// the session won't be modified concurrently.
+  [[nodiscard]] const ScanStorage& GetStorageUnsafe() const {
+    return storage_;
+  }
+
+  /// \brief Returns the configuration used for the current/last scan.
+  [[nodiscard]] ScanConfig GetConfig() const {
+    std::shared_lock lock(mutex_);
+    return config_;
+  }
+
+  /// \brief Commits new scan results to the session.
+  /// \details Called by the Scanner after a scan completes. This atomically
+  /// replaces the current storage with the new results.
+  void CommitResults(ScanStorage new_storage, ScanConfig config) {
+    std::unique_lock lock(mutex_);
+    storage_ = std::move(new_storage);
+    config_ = std::move(config);
+  }
+
+  /// \brief Updates the current values in the storage.
+  /// \details Used for live-updating the displayed values without changing
+  /// the address list.
+  void UpdateCurrentValues(std::vector<std::byte> new_current) {
+    std::unique_lock lock(mutex_);
+    storage_.curr_raw = std::move(new_current);
+  }
+
+  /// \brief Clears all scan results.
+  void Clear() {
+    std::unique_lock lock(mutex_);
+    storage_.addresses.clear();
+    storage_.curr_raw.clear();
+    storage_.prev_raw.clear();
+    storage_.stride = 0;
+  }
+
+  /// \brief Returns the number of results in the session.
+  [[nodiscard]] size_t GetResultCount() const {
+    std::shared_lock lock(mutex_);
+    return storage_.addresses.size();
+  }
+
+  /// \brief Checks if the session has any results.
+  [[nodiscard]] bool HasResults() const {
+    std::shared_lock lock(mutex_);
+    return !storage_.addresses.empty();
+  }
+
+ private:
+  mutable std::shared_mutex mutex_;
+  ScanStorage storage_;
+  ScanConfig config_;
+};
+
+}  // namespace maia::core

--- a/src/maia/core/scanner.cpp
+++ b/src/maia/core/scanner.cpp
@@ -1,0 +1,613 @@
+// Copyright (c) Maia
+
+#include "maia/core/scanner.h"
+
+#include <algorithm>
+#include <array>
+#include <future>
+#include <ranges>
+#include <span>
+#include <thread>
+#include <vector>
+
+#include "maia/core/scoped_process_suspend.h"
+#include "maia/core/simd_scanner.h"
+#include "maia/logging.h"
+
+namespace maia::core {
+
+namespace {
+
+struct ScanTask {
+  uintptr_t base_address;
+  size_t scan_size;
+  size_t read_size;
+};
+
+constexpr bool IsReadable(mmem::Protection prot) noexcept {
+  const auto prot_val = static_cast<uint32_t>(prot);
+  const auto read_val = static_cast<uint32_t>(mmem::Protection::kRead);
+  return (prot_val & read_val) != 0;
+}
+
+constexpr size_t GetDataTypeSize(ScanValueType type) {
+  switch (type) {
+    case ScanValueType::kUInt8:
+    case ScanValueType::kInt8:
+      return 1;
+    case ScanValueType::kUInt16:
+    case ScanValueType::kInt16:
+      return 2;
+    case ScanValueType::kUInt32:
+    case ScanValueType::kInt32:
+    case ScanValueType::kFloat:
+      return 4;
+    case ScanValueType::kUInt64:
+    case ScanValueType::kInt64:
+    case ScanValueType::kDouble:
+      return 8;
+    case ScanValueType::kString:
+    case ScanValueType::kWString:
+    case ScanValueType::kArrayOfBytes:
+      return 1;
+    default:
+      return 4;
+  }
+}
+
+template <typename T>
+  requires std::is_trivially_copyable_v<T>
+constexpr T LoadValue(std::span<const std::byte> bytes) {
+  std::array<std::byte, sizeof(T)> buffer{};
+  const size_t copy_size = std::min(bytes.size(), sizeof(T));
+  std::ranges::copy_n(bytes.begin(), copy_size, buffer.begin());
+  return std::bit_cast<T>(buffer);
+}
+
+constexpr bool IsValueChanged(std::span<const std::byte> current,
+                              std::span<const std::byte> previous) {
+  if (current.size() != previous.size()) {
+    return false;
+  }
+  return !std::ranges::equal(current, previous);
+}
+
+template <typename T>
+  requires std::is_trivially_copyable_v<T>
+constexpr bool IsValueDecreased(std::span<const std::byte> current,
+                                std::span<const std::byte> previous) {
+  if (current.size() < sizeof(T) || previous.size() < sizeof(T)) {
+    return false;
+  }
+  return LoadValue<T>(current) < LoadValue<T>(previous);
+}
+
+template <typename T>
+  requires std::is_trivially_copyable_v<T>
+constexpr bool IsValueIncreased(std::span<const std::byte> current,
+                                std::span<const std::byte> previous) {
+  if (current.size() < sizeof(T) || previous.size() < sizeof(T)) {
+    return false;
+  }
+  return LoadValue<T>(current) > LoadValue<T>(previous);
+}
+
+template <typename T>
+  requires std::is_trivially_copyable_v<T>
+constexpr bool IsValueIncreasedBy(std::span<const std::byte> current,
+                                  std::span<const std::byte> previous,
+                                  std::span<const std::byte> target) {
+  if (current.size() < sizeof(T) || previous.size() < sizeof(T) ||
+      target.size() < sizeof(T)) {
+    return false;
+  }
+  return LoadValue<T>(current) == LoadValue<T>(previous) + LoadValue<T>(target);
+}
+
+template <typename T>
+  requires std::is_trivially_copyable_v<T>
+constexpr bool IsValueDecreasedBy(std::span<const std::byte> current,
+                                  std::span<const std::byte> previous,
+                                  std::span<const std::byte> target) {
+  if (current.size() < sizeof(T) || previous.size() < sizeof(T) ||
+      target.size() < sizeof(T)) {
+    return false;
+  }
+  return LoadValue<T>(current) == LoadValue<T>(previous) - LoadValue<T>(target);
+}
+
+template <typename F, typename T>
+concept CheckScanType = requires(F& f) {
+  { f.template operator()<T>() } -> std::convertible_to<bool>;
+};
+
+template <typename F>
+concept CScanPredicate = CheckScanType<F, uint8_t> &&
+                         CheckScanType<F, uint64_t> && CheckScanType<F, double>;
+
+template <CScanPredicate Func>
+constexpr auto DispatchScanType(ScanValueType type, Func&& func) {
+  switch (type) {
+    case ScanValueType::kUInt8:
+      return func.template operator()<uint8_t>();
+    case ScanValueType::kUInt16:
+      return func.template operator()<uint16_t>();
+    case ScanValueType::kUInt32:
+      return func.template operator()<uint32_t>();
+    case ScanValueType::kUInt64:
+      return func.template operator()<uint64_t>();
+    case ScanValueType::kInt8:
+      return func.template operator()<int8_t>();
+    case ScanValueType::kInt16:
+      return func.template operator()<int16_t>();
+    case ScanValueType::kInt32:
+      return func.template operator()<int32_t>();
+    case ScanValueType::kInt64:
+      return func.template operator()<int64_t>();
+    case ScanValueType::kFloat:
+      return func.template operator()<float>();
+    case ScanValueType::kDouble:
+      return func.template operator()<double>();
+    default:
+      return false;
+  }
+}
+
+}  // namespace
+
+ScanResult Scanner::FirstScan(IProcess& process,
+                              const ScanConfig& config,
+                              std::stop_token stop_token,
+                              ProgressCallback progress_callback) const {
+  ScanResult result;
+
+  if (!config.Validate()) {
+    result.error_message = "Invalid scan configuration";
+    return result;
+  }
+
+  if (!process.IsProcessValid()) {
+    result.error_message = "Process is not valid";
+    return result;
+  }
+
+  std::optional<ScopedProcessSuspend> suspend;
+  if (config.pause_while_scanning) {
+    suspend.emplace(&process);
+  }
+
+  const bool is_exact_scan = (config.comparison == ScanComparison::kExactValue);
+  size_t scan_stride = 0;
+
+  if (is_exact_scan) {
+    if (config.value.empty()) {
+      result.error_message = "Exact value scan requires a value";
+      return result;
+    }
+    scan_stride = config.value.size();
+  } else {
+    scan_stride = GetDataTypeSize(config.value_type);
+  }
+
+  if (scan_stride == 0) {
+    result.error_message = "Invalid scan stride";
+    return result;
+  }
+
+  const size_t alignment = config.alignment;
+
+  ScanStorage storage;
+  storage.stride = scan_stride;
+  storage.value_type = config.value_type;
+
+  auto regions = process.GetMemoryRegions();
+  const size_t overlap_size = scan_stride > 1 ? scan_stride - 1 : 0;
+  const size_t overlap = is_exact_scan ? overlap_size : 0;
+
+  std::vector<ScanTask> tasks;
+  for (const auto& region : regions) {
+    if (stop_token.stop_requested()) {
+      break;
+    }
+    if (!IsReadable(region.protection)) {
+      continue;
+    }
+
+    const uintptr_t region_end = region.base + region.size;
+    uintptr_t current_addr = region.base;
+
+    while (current_addr < region_end) {
+      size_t chunk_scan_size = std::min(chunk_size_, region_end - current_addr);
+      size_t chunk_read_size = chunk_scan_size + overlap;
+      if (current_addr + chunk_read_size > region_end) {
+        chunk_read_size = region_end - current_addr;
+      }
+
+      tasks.emplace_back(ScanTask{.base_address = current_addr,
+                                  .scan_size = chunk_scan_size,
+                                  .read_size = chunk_read_size});
+      current_addr += chunk_scan_size;
+    }
+  }
+
+  const size_t total_tasks = tasks.size();
+  if (total_tasks == 0) {
+    result.success = true;
+    return result;
+  }
+
+  std::atomic<size_t> processed_tasks{0};
+
+  const size_t num_threads = std::max(1u, std::thread::hardware_concurrency());
+  std::vector<std::vector<ScanTask>> thread_batches(num_threads);
+  for (size_t i = 0; i < total_tasks; ++i) {
+    thread_batches[i % num_threads].emplace_back(tasks[i]);
+  }
+
+  auto worker =
+      [&process,
+       is_exact_scan,
+       scan_stride,
+       alignment,
+       &config,
+       &stop_token,
+       &processed_tasks,
+       total_tasks,
+       &progress_callback](const std::vector<ScanTask>& batch) -> ScanStorage {
+    ScanStorage local_storage;
+    local_storage.stride = scan_stride;
+    local_storage.addresses.reserve(1024);
+    local_storage.curr_raw.reserve(1024 * scan_stride);
+
+    std::vector<std::byte> buffer;
+
+    for (const auto& task : batch) {
+      if (stop_token.stop_requested()) {
+        return {};
+      }
+
+      buffer.resize(task.read_size);
+      MemoryAddress addr = task.base_address;
+      if (!process.ReadMemory({&addr, 1}, task.read_size, buffer)) {
+        ++processed_tasks;
+        if (progress_callback) {
+          progress_callback(static_cast<float>(processed_tasks) /
+                            static_cast<float>(total_tasks));
+        }
+        continue;
+      }
+
+      if (is_exact_scan) {
+        auto callback = [&](size_t offset) {
+          if (offset >= task.scan_size) {
+            return;
+          }
+          local_storage.addresses.emplace_back(task.base_address + offset);
+          local_storage.curr_raw.insert(local_storage.curr_raw.end(),
+                                        buffer.begin() + offset,
+                                        buffer.begin() + offset + scan_stride);
+        };
+
+        if (config.mask.empty()) {
+          ScanBuffer(buffer, config.value, alignment, callback);
+        } else {
+          ScanBufferMasked(buffer, config.value, config.mask, callback);
+        }
+      } else {
+        if (buffer.size() >= scan_stride) {
+          const size_t limit =
+              std::min(buffer.size() - scan_stride, task.scan_size);
+          for (size_t offset = 0; offset <= limit; offset += alignment) {
+            auto data_start = buffer.begin() + offset;
+            local_storage.addresses.emplace_back(task.base_address + offset);
+            local_storage.curr_raw.insert(local_storage.curr_raw.end(),
+                                          data_start,
+                                          data_start + scan_stride);
+          }
+        }
+      }
+
+      ++processed_tasks;
+      if (progress_callback) {
+        progress_callback(static_cast<float>(processed_tasks) /
+                          static_cast<float>(total_tasks));
+      }
+    }
+    return local_storage;
+  };
+
+  std::vector<std::future<ScanStorage>> futures;
+  for (const auto& batch : thread_batches) {
+    if (!batch.empty()) {
+      futures.emplace_back(std::async(std::launch::async, worker, batch));
+    }
+  }
+
+  // Collect all partial results first.
+  std::vector<ScanStorage> partial_results;
+  partial_results.reserve(futures.size());
+  for (auto& future : futures) {
+    if (stop_token.stop_requested()) {
+      break;
+    }
+    partial_results.emplace_back(future.get());
+  }
+
+  if (stop_token.stop_requested()) {
+    result.error_message = "Scan cancelled";
+    return result;
+  }
+
+  // Calculate total size and reserve memory upfront to avoid reallocations.
+  size_t total_addresses = 0;
+  size_t total_raw_bytes = 0;
+  for (const auto& partial : partial_results) {
+    total_addresses += partial.addresses.size();
+    total_raw_bytes += partial.curr_raw.size();
+  }
+
+  storage.addresses.reserve(total_addresses);
+  storage.curr_raw.reserve(total_raw_bytes);
+
+  // Merge all partial results into the final storage.
+  for (auto& partial : partial_results) {
+    storage.addresses.insert(storage.addresses.end(),
+                             std::make_move_iterator(partial.addresses.begin()),
+                             std::make_move_iterator(partial.addresses.end()));
+    storage.curr_raw.insert(storage.curr_raw.end(),
+                            std::make_move_iterator(partial.curr_raw.begin()),
+                            std::make_move_iterator(partial.curr_raw.end()));
+  }
+
+  storage.prev_raw = storage.curr_raw;
+  result.storage = std::move(storage);
+  result.success = true;
+
+  LogInfo("FirstScan complete. Found {} addresses.",
+          result.storage.addresses.size());
+
+  return result;
+}
+
+ScanResult Scanner::NextScan(IProcess& process,
+                             const ScanConfig& config,
+                             const ScanStorage& previous_results,
+                             std::stop_token stop_token,
+                             ProgressCallback progress_callback) const {
+  ScanResult result;
+
+  if (!config.Validate()) {
+    result.error_message = "Invalid scan configuration";
+    return result;
+  }
+
+  if (!process.IsProcessValid()) {
+    result.error_message = "Process is not valid";
+    return result;
+  }
+
+  if (previous_results.addresses.empty()) {
+    result.error_message = "No previous results to filter";
+    return result;
+  }
+
+  std::optional<ScopedProcessSuspend> suspend;
+  if (config.pause_while_scanning) {
+    suspend.emplace(&process);
+  }
+
+  const size_t count = previous_results.addresses.size();
+  const size_t stride = previous_results.stride;
+  constexpr size_t kBatchSize = 65536;
+
+  ScanStorage filtered_storage;
+  filtered_storage.stride = stride;
+  filtered_storage.value_type = previous_results.value_type;
+  filtered_storage.addresses.reserve(count / 2);
+  filtered_storage.curr_raw.reserve((count / 2) * stride);
+  filtered_storage.prev_raw.reserve((count / 2) * stride);
+
+  std::vector<std::byte> batch_buffer;
+  batch_buffer.reserve(kBatchSize * stride);
+  std::vector<uint8_t> batch_success_mask;
+  batch_success_mask.reserve(kBatchSize);
+  std::vector<uintptr_t> batch_addresses;
+  batch_addresses.reserve(kBatchSize);
+
+  size_t processed_count = 0;
+
+  for (size_t batch_start = 0; batch_start < count; batch_start += kBatchSize) {
+    if (stop_token.stop_requested()) {
+      result.error_message = "Scan cancelled";
+      return result;
+    }
+
+    const size_t batch_count = std::min(kBatchSize, count - batch_start);
+
+    batch_addresses.assign(
+        previous_results.addresses.begin() + batch_start,
+        previous_results.addresses.begin() + batch_start + batch_count);
+
+    batch_buffer.resize(batch_count * stride);
+    batch_success_mask.assign(batch_count, 0);
+
+    if (!process.ReadMemory(
+            batch_addresses, stride, batch_buffer, &batch_success_mask)) {
+      processed_count += batch_count;
+      if (progress_callback) {
+        progress_callback(static_cast<float>(processed_count) /
+                          static_cast<float>(count));
+      }
+      continue;
+    }
+
+    std::span<const std::byte> prev_span(
+        previous_results.prev_raw.data() + (batch_start * stride),
+        batch_count * stride);
+
+    const auto check_condition = [&](std::span<const std::byte> curr,
+                                     std::span<const std::byte> prev,
+                                     size_t relative_index) -> bool {
+      if (relative_index < batch_success_mask.size() &&
+          batch_success_mask[relative_index] == 0) {
+        return false;
+      }
+
+      switch (config.comparison) {
+        case ScanComparison::kChanged:
+          return IsValueChanged(curr, prev);
+        case ScanComparison::kUnchanged:
+          return !IsValueChanged(curr, prev);
+
+        case ScanComparison::kIncreased:
+          return DispatchScanType(config.value_type, [&]<typename T>() {
+            return IsValueIncreased<T>(curr, prev);
+          });
+
+        case ScanComparison::kDecreased:
+          return DispatchScanType(config.value_type, [&]<typename T>() {
+            return IsValueDecreased<T>(curr, prev);
+          });
+
+        case ScanComparison::kIncreasedBy:
+          return DispatchScanType(config.value_type, [&]<typename T>() {
+            return IsValueIncreasedBy<T>(curr, prev, std::span{config.value});
+          });
+
+        case ScanComparison::kDecreasedBy:
+          return DispatchScanType(config.value_type, [&]<typename T>() {
+            return IsValueDecreasedBy<T>(curr, prev, std::span{config.value});
+          });
+
+        case ScanComparison::kExactValue:
+          return std::ranges::equal(curr, config.value);
+
+        default:
+          return false;
+      }
+    };
+
+    auto callback = [&](size_t offset) {
+      if (offset % stride != 0) {
+        return;
+      }
+      const size_t relative_index = offset / stride;
+      if (relative_index >= batch_count) {
+        return;
+      }
+      if (relative_index < batch_success_mask.size() &&
+          batch_success_mask[relative_index] == 0) {
+        return;
+      }
+
+      const size_t absolute_index = batch_start + relative_index;
+      filtered_storage.addresses.emplace_back(
+          previous_results.addresses[absolute_index]);
+
+      const auto val_start = batch_buffer.begin() + offset;
+      filtered_storage.curr_raw.insert(
+          filtered_storage.curr_raw.end(), val_start, val_start + stride);
+      filtered_storage.prev_raw.insert(
+          filtered_storage.prev_raw.end(), val_start, val_start + stride);
+    };
+
+    if (config.comparison == ScanComparison::kExactValue) {
+      if (config.mask.empty()) {
+        ScanBuffer(batch_buffer, config.value, stride, callback);
+      } else {
+        ScanBufferMasked(batch_buffer, config.value, config.mask, callback);
+      }
+    } else if (config.comparison == ScanComparison::kChanged ||
+               config.comparison == ScanComparison::kUnchanged) {
+      const bool find_equal = (config.comparison == ScanComparison::kUnchanged);
+      ScanMemCmp(batch_buffer, prev_span, find_equal, stride, callback);
+    } else if ((config.comparison == ScanComparison::kIncreased ||
+                config.comparison == ScanComparison::kDecreased) &&
+               (config.value_type == ScanValueType::kInt32 ||
+                config.value_type == ScanValueType::kFloat)) {
+      const bool greater = (config.comparison == ScanComparison::kIncreased);
+      if (config.value_type == ScanValueType::kInt32) {
+        if (greater) {
+          ScanMemCompareGreater<int32_t>(batch_buffer, prev_span, callback);
+        } else {
+          ScanMemCompareGreater<int32_t>(prev_span, batch_buffer, callback);
+        }
+      } else {
+        if (greater) {
+          ScanMemCompareGreater<float>(batch_buffer, prev_span, callback);
+        } else {
+          ScanMemCompareGreater<float>(prev_span, batch_buffer, callback);
+        }
+      }
+    } else {
+      const std::byte* curr_ptr = batch_buffer.data();
+      const std::byte* prev_ptr = prev_span.data();
+
+      for (size_t i = 0; i < batch_count; ++i) {
+        std::span<const std::byte> val_curr(curr_ptr, stride);
+        std::span<const std::byte> val_prev(prev_ptr, stride);
+
+        if (check_condition(val_curr, val_prev, i)) {
+          filtered_storage.addresses.emplace_back(
+              previous_results.addresses[batch_start + i]);
+          filtered_storage.curr_raw.insert(filtered_storage.curr_raw.end(),
+                                           val_curr.begin(),
+                                           val_curr.end());
+          filtered_storage.prev_raw.insert(filtered_storage.prev_raw.end(),
+                                           val_curr.begin(),
+                                           val_curr.end());
+        }
+
+        curr_ptr += stride;
+        prev_ptr += stride;
+      }
+    }
+
+    processed_count += batch_count;
+    if (progress_callback) {
+      progress_callback(static_cast<float>(processed_count) /
+                        static_cast<float>(count));
+    }
+  }
+
+  result.storage = std::move(filtered_storage);
+  result.success = true;
+
+  LogInfo("NextScan complete. {} addresses remaining.",
+          result.storage.addresses.size());
+
+  return result;
+}
+
+std::future<ScanResult> Scanner::FirstScanAsync(
+    IProcess& process,
+    const ScanConfig& config,
+    std::stop_token stop_token,
+    ProgressCallback progress_callback) const {
+  return std::async(std::launch::async,
+                    [this, &process, config, stop_token, progress_callback]() {
+                      return FirstScan(
+                          process, config, stop_token, progress_callback);
+                    });
+}
+
+std::future<ScanResult> Scanner::NextScanAsync(
+    IProcess& process,
+    const ScanConfig& config,
+    const ScanStorage& previous_results,
+    std::stop_token stop_token,
+    ProgressCallback progress_callback) const {
+  return std::async(
+      std::launch::async,
+      [this,
+       &process,
+       config,
+       previous_results,
+       stop_token,
+       progress_callback]() {
+        return NextScan(
+            process, config, previous_results, stop_token, progress_callback);
+      });
+}
+
+}  // namespace maia::core

--- a/src/maia/core/scanner.h
+++ b/src/maia/core/scanner.h
@@ -1,0 +1,100 @@
+// Copyright (c) Maia
+
+#pragma once
+
+#include <cstddef>
+#include <functional>
+#include <future>
+#include <stop_token>
+
+#include "maia/core/i_process.h"
+#include "maia/core/scan_config.h"
+#include "maia/core/scan_types.h"
+
+namespace maia::core {
+
+/// \brief Result of a scan operation.
+struct ScanResult {
+  ScanStorage storage;
+  bool success = false;
+  std::string error_message;
+};
+
+/// \brief Progress callback signature.
+/// \param progress Value between 0.0 and 1.0 indicating completion percentage.
+using ProgressCallback = std::function<void(float progress)>;
+
+/// \brief Stateless memory scanner service.
+/// \details Performs memory scanning operations given an IProcess and
+/// ScanConfig. This class is designed to be used by both GUI and CLI without
+/// any UI dependencies. Each Scan() call is independent and does not retain
+/// state between calls.
+class Scanner {
+ public:
+  Scanner() = default;
+  ~Scanner() = default;
+
+  Scanner(const Scanner&) = delete;
+  Scanner& operator=(const Scanner&) = delete;
+  Scanner(Scanner&&) = default;
+  Scanner& operator=(Scanner&&) = default;
+
+  /// \brief Performs a first scan (searches all memory regions).
+  /// \param process The target process to scan.
+  /// \param config The scan configuration.
+  /// \param stop_token Token to request cancellation.
+  /// \param progress_callback Optional callback for progress updates.
+  /// \return The scan results.
+  [[nodiscard]] ScanResult FirstScan(
+      IProcess& process,
+      const ScanConfig& config,
+      std::stop_token stop_token = {},
+      ProgressCallback progress_callback = nullptr) const;
+
+  /// \brief Performs a next scan (filters existing results).
+  /// \param process The target process to scan.
+  /// \param config The scan configuration.
+  /// \param previous_results The results from the previous scan to filter.
+  /// \param stop_token Token to request cancellation.
+  /// \param progress_callback Optional callback for progress updates.
+  /// \return The filtered scan results.
+  [[nodiscard]] ScanResult NextScan(
+      IProcess& process,
+      const ScanConfig& config,
+      const ScanStorage& previous_results,
+      std::stop_token stop_token = {},
+      ProgressCallback progress_callback = nullptr) const;
+
+  /// \brief Async version of FirstScan.
+  /// \return A future that will contain the scan results.
+  [[nodiscard]] std::future<ScanResult> FirstScanAsync(
+      IProcess& process,
+      const ScanConfig& config,
+      std::stop_token stop_token = {},
+      ProgressCallback progress_callback = nullptr) const;
+
+  /// \brief Async version of NextScan.
+  /// \return A future that will contain the scan results.
+  [[nodiscard]] std::future<ScanResult> NextScanAsync(
+      IProcess& process,
+      const ScanConfig& config,
+      const ScanStorage& previous_results,
+      std::stop_token stop_token = {},
+      ProgressCallback progress_callback = nullptr) const;
+
+  /// \brief Sets the chunk size for memory reading.
+  /// \param size The chunk size in bytes (default: 32MB).
+  void SetChunkSize(size_t size) {
+    chunk_size_ = size;
+  }
+
+  /// \brief Gets the current chunk size.
+  [[nodiscard]] size_t GetChunkSize() const {
+    return chunk_size_;
+  }
+
+ private:
+  size_t chunk_size_ = 32 * 1024 * 1024;  // 32 MB default
+};
+
+}  // namespace maia::core


### PR DESCRIPTION
- Decouple scanning logic from UI model into `Scanner` and `ScanSession` components in `src/maia/core`.
- Fix race condition where applying results used current UI config instead of scan-time config by capturing state in `pending_config_`.
- Fix UI hang during destruction by ensuring active scans are explicitly cancelled.
- Improve test reliability by replacing sleeps with deterministic `WaitForScanToFinish` synchronization.